### PR TITLE
パンくずリスト機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'payjp'
 gem 'pry-rails'
 gem "aws-sdk-s3", require: false
 gem 'rails-i18n'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.1.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -356,6 +359,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gretel
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,6 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
+<% breadcrumb :edit %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,6 +130,7 @@
       <li class='list'>
         <div class='item-img-content'>
           <%= link_to item_path(item.id), method: :get do %>
+            <% breadcrumb :root %>
             <%= image_tag item.images[0], class: "images"%>
           <% end %>
             <%# 商品が売れていればsold outの表示   %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,6 +1,7 @@
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+    <% breadcrumb :new_item %>
 
   </header>
   <div class="items-sell-main">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,12 +30,14 @@
     <%# 出品者のみ表示 %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+      <% breadcrumb :items %>
       <p class='or-text'>or</p>
       <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
     <% end %>
     <%# 出品者以外表示 %>
     <% if user_signed_in? && current_user.id != @item.user_id %>
       <%= link_to '購入画面に進む', item_purchases_path(@item) ,class:"item-red-btn"%>
+      <% breadcrumb :items %>
     <% end %>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 </head>
 
 <body>
+  <%= breadcrumbs separator: " &rsaquo; " %>   
   <%= yield %>
 </body>
 

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/second-header"%>
-
+<% breadcrumb :purchases, @item %>
 <div class='transaction-contents'>
   <div class='transaction-main'>
     <h1 class='transaction-title-text'>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,6 +2,31 @@ crumb :root do
   link "Home", root_path
 end
 
+crumb :new_item do 
+  link "商品出品", new_item_path
+  parent :root
+end
+
+crumb :items do |item|
+  link "商品詳細", item_path
+  parent :root
+end
+
+crumb :item_purchase do |item|
+  link "商品詳細", item_path(item)
+  parent :root
+end
+
+crumb :purchases do |item|
+  link "商品購入", item_purchases_path(item)
+  parent :item_purchase, item
+end
+
+crumb :edit do
+  link "商品編集", edit_item_path
+  parent :items
+end
+
 # crumb :projects do
 #   link "Projects", projects_path
 # end


### PR DESCRIPTION
# What
画面に現在位置を表示するリストの表示

# Why
現在の階層がわかりやすく、すぐ思った場所に遷移出来る。
又、今回の場合編集画面と出品画面が同じで判断材料の一つとして有効